### PR TITLE
chore: drop deprecated MDX rehypePlugins; sync project rules

### DIFF
--- a/.claude/rules/withotto-app-conventions.md
+++ b/.claude/rules/withotto-app-conventions.md
@@ -71,7 +71,7 @@ import shot from "@assets/capture/step-01-capture.png";
 
 ## Tailwind: Project Tokens
 
-- **Brand colours** are defined in `tailwind.config.cjs`. Canonical palette and copy-friendly hex values live on the `/brand-kit/` page (`src/pages/brand-kit.astro`). Use semantic Tailwind utilities (`bg-primary`, `text-primary-strong`, `border-primary-accent`, `bg-terracotta-soft`, etc.); do not hardcode hex values in components. Token shape: each colour has `.soft / .DEFAULT / .strong` (some also `.accent / .medium`).
+- **Brand colours** are defined in `src/styles/global.css` (Tailwind 4 `@theme` block, e.g. `--color-primary`, `--color-terracotta`). Canonical palette and copy-friendly hex values live on the `/brand-kit/` page (`src/pages/brand-kit.astro`). Use semantic Tailwind utilities (`bg-primary`, `text-primary-strong`, `border-primary-accent`, `bg-terracotta-soft`, etc.); do not hardcode hex values in components. Token shape: each colour has `.soft / .DEFAULT / .strong` (some also `.accent / .medium`).
 - **Font:** `font-sans` is `"Rethink Sans Variable"` (loaded via `@fontsource-variable/rethink-sans` in `RootLayout`).
 - **Typography plugin:** Use `prose` / `md:prose-lg` for long-form text. Customise with `prose-li:mt-0` etc.
 - **Form validation pattern:** Forms add a `validated` class on first submit attempt, then CSS targets `[.validated_&]:invalid:...` to reveal error messages. Preserve this pattern when adding new forms.
@@ -97,5 +97,5 @@ All redirects use `301`. Any new removals should mirror this pattern.
 
 - **Trailing slashes are mandatory** (`trailingSlash: "always"`). Links to `/foo` get a redirect; write `/foo/`.
 - **`public/` vs `src/assets/`**: `public/` is copied verbatim and served from `/`; `src/assets/` goes through Astro's image pipeline. Blog images and anything needing responsive `srcset` must live in `src/assets/`.
-- **pnpm is pinned** (`engines.pnpm: 10.x`, `packageManager: pnpm@10.15.0`). Do not commit a `package-lock.json` or `yarn.lock`.
+- **pnpm is pinned** (`engines.pnpm: 11.x`, `packageManager: pnpm@11.5.1`). Do not commit a `package-lock.json` or `yarn.lock`.
 - **Deno runtime in `supabase/functions/`**: do not import Node-style packages; use `jsr:` / `npm:` / `https://esm.sh/...` imports only.

--- a/.claude/rules/withotto-app-project.md
+++ b/.claude/rules/withotto-app-project.md
@@ -1,6 +1,6 @@
 # Project: withotto.app (v2)
 
-**Last Updated:** 2026-06-05
+**Last Updated:** 2026-06-19
 
 ## Overview
 
@@ -17,14 +17,14 @@ Homepage and shared copy should lead with the brand (tools for accountants/bookk
 
 ## Technology Stack
 
-- **Framework:** Astro 5 (static site, `trailingSlash: "always"`)
+- **Framework:** Astro 6 (static site, `trailingSlash: "always"`)
 - **Language:** TypeScript (strictNullChecks) + `.astro` components
-- **Styling:** Tailwind CSS 3 via `@astrojs/tailwind` (+ `@tailwindcss/typography`)
+- **Styling:** Tailwind CSS 4 via `@tailwindcss/vite` (+ `@tailwindcss/typography`); theme tokens in `src/styles/global.css`
 - **Content:** MDX via `@astrojs/mdx`, Astro content collections
 - **Icons:** `astro-icon` + `@iconify-json/hugeicons`
 - **SEO:** `astro-seo`, `@astrojs/sitemap`
 - **Backend:** Supabase edge functions (Deno) in `supabase/functions/`
-- **Package manager:** pnpm 10.x (pinned via `packageManager` + `engines`; also installable via `mise`)
+- **Package manager:** pnpm 11.x (pinned via `packageManager` + `engines`; also installable via `mise`)
 - **Formatter:** Prettier 3 with `prettier-plugin-astro` + `prettier-plugin-tailwindcss` (2-space indent)
 - **Link checker:** `lychee` (via `check-links` script)
 - **Hosting:** Netlify (redirects in `_redirects`)
@@ -44,13 +44,12 @@ No test framework, no ESLint, no CI config in repo. Quality gate is `format:chec
 │   ├── assets/         # Images referenced from content/components (blog/, testimonials/)
 │   ├── utils/          # Pure TS helpers (blog.ts)
 │   ├── types/          # Shared TS types
-│   └── styles/
+│   └── styles/         # global.css — Tailwind 4 @theme brand tokens
 ├── public/             # Static assets served as-is
 ├── supabase/
 │   ├── functions/      # Deno edge functions (e.g. reconciliation-stats)
 │   └── config.toml
 ├── astro.config.mjs
-├── tailwind.config.cjs
 ├── prettier.config.mjs
 └── _redirects          # Netlify redirect rules
 ```
@@ -82,7 +81,7 @@ Use these aliases in imports. Do not write relative `../../` paths:
 | Raw Astro CLI      | `pnpm astro <cmd>`                                               |
 | Supabase CLI       | `pnpm supabase <cmd>` (dev dep, use via pnpm)                    |
 
-**Always use `pnpm`.** Do not introduce `npm` or `yarn` commands; the repo is pinned to pnpm 10.x.
+**Always use `pnpm`.** Do not introduce `npm` or `yarn` commands; the repo is pinned to pnpm 11.x.
 
 ## Conventions
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,6 @@ import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import mdx from "@astrojs/mdx";
 import icon from "astro-icon";
-import slug from "rehype-slug";
 import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
@@ -10,9 +9,7 @@ export default defineConfig({
   site: "https://withotto.app",
   trailingSlash: "always",
   integrations: [
-    mdx({
-      rehypePlugins: [slug],
-    }),
+    mdx(),
     sitemap({
       filter: (url) => !url.startsWith("https://withotto.app/notebook/"),
     }),

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "astro-icon": "1.1.5",
     "astro-navbar": "2.4.0",
     "astro-seo": "1.1.0",
-    "rehype-slug": "6.0.0",
     "sharp": "0.35.1",
     "tailwindcss": "4.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       astro-seo:
         specifier: 1.1.0
         version: 1.1.0(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@6.0.3)
-      rehype-slug:
-        specifier: 6.0.0
-        version: 6.0.0
       sharp:
         specifier: 0.35.1
         version: 0.35.1
@@ -1489,9 +1486,6 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
-  hast-util-heading-rank@3.0.0:
-    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
-
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -1512,9 +1506,6 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
-
-  hast-util-to-string@3.0.1:
-    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -2124,9 +2115,6 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
-
-  rehype-slug@6.0.0:
-    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -4100,10 +4088,6 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
-  hast-util-heading-rank@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -4192,10 +4176,6 @@ snapshots:
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
-
-  hast-util-to-string@3.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -5022,14 +5002,6 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
-
-  rehype-slug@6.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      github-slugger: 2.0.0
-      hast-util-heading-rank: 3.0.0
-      hast-util-to-string: 3.0.1
-      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,6 +1,6 @@
 ---
 // This component generates a table of contents from the headings in the current page
-// It requires the headings to have IDs (which rehype-slug provides)
+// It requires the headings to have IDs, which Astro injects into Markdown/MDX headings automatically
 
 export interface Props {
   headings?: Array<{ depth: number; slug: string; text: string }>;


### PR DESCRIPTION
## What

1. **Fix the Astro MDX `rehypePlugins` deprecation.** `astro.config.mjs` passed `rehype-slug` to the MDX integration via `mdx({ rehypePlugins: [slug] })` — the option is deprecated in Astro 6.4 (removed in Astro 7). Astro already auto-injects `id` attributes into Markdown/MDX headings, so the plugin was **redundant**. Removed the plugin, its import, and the now-unused `rehype-slug` dependency (lockfile: `-rehype-slug` + its two exclusive transitives, 28 deletions, no other churn). Updated the stale comment in `TableOfContents.astro`.

2. **Sync the project rules to current state:**
   - Astro 5 → **Astro 6**
   - Tailwind CSS 3 / `@astrojs/tailwind` / `tailwind.config.cjs` → **Tailwind CSS 4 / `@tailwindcss/vite`**, theme tokens in `src/styles/global.css`
   - pnpm 10.x → **11.x** (`pnpm@11.5.1`)
   - Dropped non-existent `tailwind.config.cjs` from the directory tree; refreshed the "Last Updated" date.

## Verification

- `pnpm build` ✓ — 16 pages, **no deprecation/rehype warnings** (on astro 6.4.6).
- `pnpm format:check` ✓ — all files match Prettier.
- HTML cross-check ✓ — every TOC anchor `href` resolves to an auto-injected heading `id`.
- **Live browser click-test** (playwright-cli/WebKit) ✓ — clicking a TOC link scrolls to the heading (`scrollY 4848`, heading top at `0px`, `hash=#security-of-your-personal-information`). TOC behaviour is fully preserved without `rehype-slug`.

## Why now

Branched off the just-merged Renovate batch (Astro 6.4.6 etc.), so the rules drift surfaced during that review.