### PR TITLE
chore: keep engines.pnpm as a range, stop Renovate pinning it

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "supabase": "2.106.0"
   },
   "engines": {
-    "pnpm": "11.x"
+    "pnpm": ">=11 <12"
   },
   "packageManager": "pnpm@11.5.1"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -109,6 +109,11 @@
       "minimumReleaseAge": "5 days"
     },
     {
+      "description": "Keep engines fields as ranges, never exact pins. engines declares the supported version range; the exact selectors are packageManager + mise.toml (still pinned by the global rangeStrategy:pin). Without this override, rangeStrategy:pin rewrites engines.pnpm to an exact version that drifts from the actual pinned pnpm. 'replace' leaves the range untouched while the installed version still satisfies it, and only bumps it on a new major.",
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "replace"
+    },
+    {
       "description": "Cross-file: collapse Deno bumps from mise.toml customManager into one PR; apply 5-day supply-chain floor",
       "matchPackageNames": ["denoland/deno"],
       "groupName": "deno",

--- a/renovate.json
+++ b/renovate.json
@@ -109,7 +109,7 @@
       "minimumReleaseAge": "5 days"
     },
     {
-      "description": "Keep engines fields as ranges, never exact pins. engines declares the supported version range; the exact selectors are packageManager + mise.toml (still pinned by the global rangeStrategy:pin). Without this override, rangeStrategy:pin rewrites engines.pnpm to an exact version that drifts from the actual pinned pnpm. 'replace' leaves the range untouched while the installed version still satisfies it, and only bumps it on a new major.",
+      "description": "Keep engines fields as ranges, never exact pins. engines declares the supported version range; the exact selectors are packageManager + mise.toml (still pinned by the global rangeStrategy:pin). Without this override, rangeStrategy:pin rewrites engines.pnpm to an exact version that drifts from the actual pinned pnpm. 'replace' (unlike 'bump') only rewrites the range when a release falls outside it: pnpm 11.x minor/patch updates leave '>=11 <12' unchanged, and it changes only at a new major (pnpm 12.x).",
       "matchDepTypes": ["engines"],
       "rangeStrategy": "replace"
     },


### PR DESCRIPTION
## Problem

Renovate's global `rangeStrategy: "pin"` rewrites `engines.pnpm` from a range to an **exact** version. In the open pnpm PR (#57) this produced an inconsistency:

| Location | Version |
|---|---|
| `engines.pnpm` | `11.8.0` (exact) |
| `packageManager` | `pnpm@11.6.0` |
| `mise.toml` / `mise.lock` | `11.6.0` |

`engines` is meant to declare a *supported range*, not act as an exact selector — that's the job of `packageManager` + `mise`. Pinning it makes the declared version drift from the version actually installed.

## Fix

- **`package.json`** — `engines.pnpm`: `"11.x"` → `">=11 <12"` (bounded to the tested major; explicit comparators, same shape as before).
- **`renovate.json`** — new `packageRule`: `matchDepTypes: ["engines"]` with `rangeStrategy: "replace"`. Renovate now keeps `engines` as a range and only moves it on a new pnpm **major**. `packageManager` + `mise` stay exact-pinned by the global `pin` strategy.

`replace` leaves the range untouched while the installed version still satisfies it (so 11.6.0 / 11.8.0 won't generate engines churn), and only bumps on a new major (a `major-update`-labelled PR you review).

## Verification

- JSON parses; `prettier --check` clean.
- `rangeStrategy: "replace"` and `matchDepTypes` confirmed valid in Renovate docs.
- (The official `renovate-config-validator` could not run locally — the project's pnpm supply-chain trust policy blocks one of Renovate's own transitive deps, `semver@6.3.1`. Not bypassed.)

## Follow-up

After this merges to `main`, **rebase PR #57** so Renovate regenerates it against the new config — it will then only bump `packageManager` + `mise` to `11.6.0` and leave `engines` as `>=11 <12`.