### PR TITLE
Add Intercom chat widget (sales) to the public website

### DIFF
--- a/.claude/rules/withotto-app-conventions.md
+++ b/.claude/rules/withotto-app-conventions.md
@@ -47,6 +47,8 @@ Tribal knowledge not obvious from reading a single file. Read before touching la
 
 Swap embed URLs here; they are not configurable via env var.
 
+**Intercom (live chat)** is a third-party hosted integration (not a self-hosted subdomain): `IntercomWidget.astro`, rendered once in `RootLayout.astro` and gated on the `PUBLIC_INTERCOM_APP_ID` env var. See `.claude/rules/withotto-app-intercom.md` for how it works and the sales-oriented dashboard checklist.
+
 ## Icons
 
 - **Remote set:** `astro-icon` + `@iconify-json/hugeicons`. Example: `<Icon name="hugeicons:calendar-03" size={32} class="..." />`

--- a/.claude/rules/withotto-app-intercom.md
+++ b/.claude/rules/withotto-app-intercom.md
@@ -1,0 +1,52 @@
+# Intercom Messenger (website live chat)
+
+How the public site's Intercom integration works in code, and the checklist for configuring the Intercom dashboard for sales. Load when touching the chat widget, the Messenger config, or the sales conversation setup.
+
+## What the code does
+
+The website embeds the Intercom Messenger for anonymous visitors via `src/components/IntercomWidget.astro`, rendered once in `src/layouts/RootLayout.astro` (so it appears on every page, both `.astro` pages and `.mdx` legal pages). The code handles:
+
+- Loading the Messenger for anonymous visitors (no logged-in user, so no Identity Verification secret is needed).
+- The EU data region (`api_base` is `https://api-iam.eu.intercom.io`).
+- The brand colour as a hint (`#02ac8a`, the `--color-primary` token).
+- A `product` attribute set from the page path ("Otto Capture" on `/capture/`, "Otto Bank Rec" on `/bank-reconciliation/`, "Website (general)" elsewhere), so a sales rep sees which product a visitor was looking at.
+- Deferred loading: the external widget script is fetched on browser idle or first interaction, so it does not block the initial render.
+
+Everything else, the greeting, the bots, the routing, and the appearance, is configured in the Intercom dashboard. The rest of this page is the checklist for that configuration.
+
+The website is more likely to bring sales enquiries than the tech-support conversations the Bank Rec portal and the Otto Capture app handle. The settings below tune the same workspace for that difference, without changing the support experience in the other two products.
+
+## Before you start
+
+- **Workspace:** the website uses the same Intercom workspace as the Bank Rec portal and the Otto Capture app, so conversations land in the existing inbox. There is no second workspace to manage.
+- **Region:** the workspace is on Intercom's EU data region. The code already points at `https://api-iam.eu.intercom.io`.
+- **App ID:** set `PUBLIC_INTERCOM_APP_ID` to the workspace ID (the string after `apps/` in the Intercom URL). Add it to `.env.development` for local work and to the Netlify build environment variables for production. The widget renders nothing until this is set, so the site is safe to ship before the value is in place.
+
+## Greeting and prompts
+
+The existing integrations greet people with a support framing. Give the website its own sales-oriented greeting, targeted by URL (`withotto.app`) or by audience so it does not change the greeting in the portal or the app.
+
+- Lead with the question a prospect actually has, for example "Looking at Otto for your practice? Ask us anything about Capture or Bank Rec."
+- Keep the tone measured and no-pressure, in line with the rest of the site.
+- Avoid support phrasing such as "How can we help you today?", which reads as a ticket queue rather than a sales conversation.
+
+## Qualification and routing
+
+- Add a short bot or Fin flow that asks which product the visitor is interested in (Otto Capture or Otto Bank Rec) and the rough size of their practice, then hands off to a person.
+- The widget sends a `product` attribute set from the page ("Otto Capture", "Otto Bank Rec", or "Website (general)"). Use it, or the page URL, to route website conversations to a sales assignee or inbox, separate from the support queue that the portal and the app feed.
+- Define a custom data attribute named `product` in Intercom settings so the value shows on the lead in the inbox. It still works if undefined, it just will not be displayed.
+
+## Appearance
+
+- Set the Messenger action colour to the brand primary `#02ac8a` and add the With Otto logo. The dashboard appearance is what actually controls the launcher colour, so set it here even though the code also passes the colour as a hint.
+- Confirm the Messenger is using the EU data region.
+
+## Availability and expectations
+
+- Set office hours and an expected reply time so visitors know when to expect an answer.
+- Configure an email fallback for out-of-hours messages, consistent with the support promise to reply within a working day.
+
+## Optional proactive message
+
+- Consider a low-key outbound message on the pricing or product pages, for example offering to answer questions about the Capture pricing tiers.
+- Keep it optional and easy to dismiss. No countdowns, no fake scarcity, no pressure tactics.

--- a/.claude/rules/withotto-app-intercom.md
+++ b/.claude/rules/withotto-app-intercom.md
@@ -7,7 +7,7 @@ How the public site's Intercom integration works in code, and the checklist for 
 The website embeds the Intercom Messenger for anonymous visitors via `src/components/IntercomWidget.astro`, rendered once in `src/layouts/RootLayout.astro` (so it appears on every page, both `.astro` pages and `.mdx` legal pages). The code handles:
 
 - Loading the Messenger for anonymous visitors (no logged-in user, so no Identity Verification secret is needed).
-- The EU data region (`api_base` is `https://api-iam.eu.intercom.io`).
+- The US data region (`api_base` is `https://api-iam.intercom.io`).
 - The brand colour as a hint (`#02ac8a`, the `--color-primary` token).
 - A `product` attribute set from the page path ("Otto Capture" on `/capture/`, "Otto Bank Rec" on `/bank-reconciliation/`, "Website (general)" elsewhere), so a sales rep sees which product a visitor was looking at.
 - Deferred loading: the external widget script is fetched on browser idle or first interaction, so it does not block the initial render.
@@ -19,7 +19,7 @@ The website is more likely to bring sales enquiries than the tech-support conver
 ## Before you start
 
 - **Workspace:** the website uses the same Intercom workspace as the Bank Rec portal and the Otto Capture app, so conversations land in the existing inbox. There is no second workspace to manage.
-- **Region:** the workspace is on Intercom's EU data region. The code already points at `https://api-iam.eu.intercom.io`.
+- **Region:** the workspace is on Intercom's US data region. The code already points at `https://api-iam.intercom.io`.
 - **App ID:** set `PUBLIC_INTERCOM_APP_ID` to the workspace ID (the string after `apps/` in the Intercom URL). Add it to `.env.development` for local work and to the Netlify build environment variables for production. The widget renders nothing until this is set, so the site is safe to ship before the value is in place.
 
 ## Greeting and prompts
@@ -39,7 +39,7 @@ The existing integrations greet people with a support framing. Give the website 
 ## Appearance
 
 - Set the Messenger action colour to the brand primary `#02ac8a` and add the With Otto logo. The dashboard appearance is what actually controls the launcher colour, so set it here even though the code also passes the colour as a hint.
-- Confirm the Messenger is using the EU data region.
+- Confirm the Messenger is using the US data region.
 
 ## Availability and expectations
 

--- a/src/components/IntercomWidget.astro
+++ b/src/components/IntercomWidget.astro
@@ -1,0 +1,89 @@
+---
+// Intercom Messenger for anonymous website visitors, tuned for sales enquiries.
+// Rendered by RootLayout only when PUBLIC_INTERCOM_APP_ID is set, so appId is
+// always a non-empty string here. The app id is public and ships in the HTML.
+export interface Props {
+  appId: string;
+}
+
+const { appId } = Astro.props;
+
+// EU data region (confirmed with the workspace owner).
+const apiBase = "https://api-iam.eu.intercom.io";
+
+// Brand --color-primary (src/styles/global.css). Intercom's JS config needs a
+// literal hex; the authoritative launcher colour is set in the Intercom
+// dashboard (see docs/intercom-messenger-setup.md).
+const actionColor = "#02ac8a";
+
+// Give sales the page context. Trailing slashes are intentional:
+// trailingSlash:"always" guarantees every path ends in "/", so "/capture/"
+// cannot collide with e.g. "/capture-foo/".
+const pathname = Astro.url.pathname;
+const product = pathname.startsWith("/capture/")
+  ? "Otto Capture"
+  : pathname.startsWith("/bank-reconciliation/")
+    ? "Otto Bank Rec"
+    : "Website (general)";
+---
+
+<script is:inline define:vars={{ appId, apiBase, actionColor, product }}>
+  window.intercomSettings = {
+    app_id: appId,
+    api_base: apiBase,
+    action_color: actionColor,
+    background_color: actionColor,
+    product: product,
+  };
+  (function () {
+    var w = window;
+    var ic = w.Intercom;
+    if (typeof ic === "function") {
+      ic("reattach_activator");
+      ic("update", w.intercomSettings);
+      return;
+    }
+    var d = document;
+    var i = function () {
+      i.c(arguments);
+    };
+    i.q = [];
+    i.c = function (args) {
+      i.q.push(args);
+    };
+    w.Intercom = i;
+    var loaded = false;
+    function load() {
+      if (loaded) return;
+      loaded = true;
+      var s = d.createElement("script");
+      s.type = "text/javascript";
+      s.async = true;
+      s.src = "https://widget.intercom.io/widget/" + appId;
+      var x = d.getElementsByTagName("script")[0];
+      x.parentNode.insertBefore(s, x);
+    }
+    // Defer the external widget fetch to protect page-speed: load on the first
+    // user interaction or when the browser is idle, whichever comes first.
+    var events = ["mousemove", "scroll", "touchstart", "keydown", "click"];
+    function onInteract() {
+      load();
+      events.forEach(function (e) {
+        w.removeEventListener(e, onInteract);
+      });
+    }
+    events.forEach(function (e) {
+      w.addEventListener(e, onInteract, { once: true, passive: true });
+    });
+    if ("requestIdleCallback" in w) {
+      w.requestIdleCallback(load, { timeout: 6000 });
+    } else if (d.readyState === "complete") {
+      // load event already fired (script sits at end of body): schedule directly
+      setTimeout(load, 3000);
+    } else {
+      w.addEventListener("load", function () {
+        setTimeout(load, 3000);
+      });
+    }
+  })();
+</script>

--- a/src/components/IntercomWidget.astro
+++ b/src/components/IntercomWidget.astro
@@ -53,24 +53,26 @@ const product = pathname.startsWith("/capture/")
     };
     w.Intercom = i;
     var loaded = false;
+    // Defer the external widget fetch to protect page-speed: load on the first
+    // user interaction or when the browser is idle, whichever comes first.
+    var events = ["mousemove", "scroll", "touchstart", "keydown", "click"];
+    function onInteract() {
+      load();
+    }
     function load() {
       if (loaded) return;
       loaded = true;
+      // Detach the interaction listeners up front so an idle- or load-triggered
+      // load does not leave them attached waiting to fire a no-op.
+      events.forEach(function (e) {
+        w.removeEventListener(e, onInteract);
+      });
       var s = d.createElement("script");
       s.type = "text/javascript";
       s.async = true;
       s.src = "https://widget.intercom.io/widget/" + appId;
       var x = d.getElementsByTagName("script")[0];
       x.parentNode.insertBefore(s, x);
-    }
-    // Defer the external widget fetch to protect page-speed: load on the first
-    // user interaction or when the browser is idle, whichever comes first.
-    var events = ["mousemove", "scroll", "touchstart", "keydown", "click"];
-    function onInteract() {
-      load();
-      events.forEach(function (e) {
-        w.removeEventListener(e, onInteract);
-      });
     }
     events.forEach(function (e) {
       w.addEventListener(e, onInteract, { once: true, passive: true });

--- a/src/components/IntercomWidget.astro
+++ b/src/components/IntercomWidget.astro
@@ -8,12 +8,12 @@ export interface Props {
 
 const { appId } = Astro.props;
 
-// EU data region (confirmed with the workspace owner).
-const apiBase = "https://api-iam.eu.intercom.io";
+// US data region.
+const apiBase = "https://api-iam.intercom.io";
 
 // Brand --color-primary (src/styles/global.css). Intercom's JS config needs a
-// literal hex; the authoritative launcher colour is set in the Intercom
-// dashboard (see docs/intercom-messenger-setup.md).
+// literal hex; the launcher colour is ultimately controlled in the Intercom
+// dashboard.
 const actionColor = "#02ac8a";
 
 // Give sales the page context. Trailing slashes are intentional:

--- a/src/layouts/RootLayout.astro
+++ b/src/layouts/RootLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { SEO } from "astro-seo";
 import type { SEOProps } from "astro-seo";
+import IntercomWidget from "@components/IntercomWidget.astro";
 import "@fontsource-variable/rethink-sans";
 import "../styles/global.css";
 
@@ -11,6 +12,8 @@ export interface Props {
 }
 
 const { title, affiliateProgramId, seo = {} } = Astro.props;
+
+const intercomAppId = import.meta.env.PUBLIC_INTERCOM_APP_ID;
 
 const makeTitle = title
   ? title + " — " + "With Otto"
@@ -78,5 +81,6 @@ const defaultDescription =
   </head>
   <body class="flex min-h-full flex-col font-sans antialiased">
     <slot />
+    {intercomAppId && <IntercomWidget appId={intercomAppId} />}
   </body>
 </html>

--- a/src/pages/cookie-policy.mdx
+++ b/src/pages/cookie-policy.mdx
@@ -1,12 +1,14 @@
 ---
 title: Cookie Policy
 layout: "layouts/MdLayout.astro"
-lastUpdated: 2026-04-09
+lastUpdated: 2026-06-23
 ---
 
 We use cookies to help improve your experience of our services. This cookie policy is part of With Otto's privacy policy. It covers the use of cookies between your device and our site.
 
 We also provide basic information on third-party services we may use, who may also use cookies as part of their service. This policy does not cover their cookies.
+
+For example, we use Intercom to provide live chat on our website. When the chat messenger loads, Intercom sets cookies (such as intercom-id and intercom-session) to keep your chat session and conversation history working across visits.
 
 If you don’t wish to accept cookies from us, you should instruct your browser to refuse cookies from the individual withotto.app domains. In such a case, we may be unable to provide you with some of your desired content and services.
 
@@ -22,7 +24,7 @@ Cookies set by other sites and companies (i.e. third parties) are called third-p
 
 ## How can you control our website's use of cookies?
 
-You have the right to decide whether to accept or reject cookies on our Website. You can manage your cookie preferences in our Cookie Consent Manager. The Cookie Consent Manager allows you to select which categories of cookies you accept or reject. Essential cookies cannot be rejected as they are strictly necessary to provide you with the services on our Website.
+You have the right to decide whether to accept or reject cookies on our Website. You can accept or reject non-essential cookies by managing your web browser settings, as described in the section below. Essential cookies cannot be rejected as they are strictly necessary to provide you with the services on our Website.
 
 You may also be able to set or amend your cookie preferences by managing your web browser settings. As each web browser is different, please consult the instructions provided by your web browser (typically in the "help" section). If you choose to refuse or disable cookies you may still use the Website, though some of the functionality of the Website may not be available to you.
 

--- a/src/pages/privacy-policy.mdx
+++ b/src/pages/privacy-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy
 layout: "layouts/MdLayout.astro"
-lastUpdated: 2026-06-18
+lastUpdated: 2026-06-23
 ---
 
 Your privacy is important to us. It is With Otto's policy to respect your privacy and comply with any applicable law and regulation regarding any personal information we may collect about you, including across our website, withotto.app, and other sites we own and operate.
@@ -12,7 +12,7 @@ In the event our site contains links to third-party sites and services, please b
 
 This policy is effective as of 18 June 2026
 
-Last updated: 18 June 2026
+Last updated: 23 June 2026
 
 ## Information we collect
 
@@ -99,6 +99,7 @@ Third parties we currently use include:
 - Langfuse, for monitoring and debugging our document processing
 - Stripe, for processing payments
 - PostHog, for product analytics and monitoring
+- Intercom, for live chat and customer messaging on our website
 
 ## International transfers of personal information
 


### PR DESCRIPTION
## Summary

Adds the Intercom Messenger chat widget to every page of the public marketing site, configured for **sales** enquiries (the Bank Rec portal and Capture app use Intercom for support; this is the website's first integration).

## What changed

- **`src/components/IntercomWidget.astro`** (new) + **`src/layouts/RootLayout.astro`** — Intercom Messenger for anonymous visitors:
  - Same Intercom workspace as the existing apps, **US** data region (`api-iam.intercom.io`).
  - Brand-coloured launcher hint (`action_color` = `#02ac8a`); the dashboard remains authoritative for appearance.
  - A `product` lead attribute derived from the page (`Otto Capture` on `/capture/`, `Otto Bank Rec` on `/bank-reconciliation/`, `Website (general)` elsewhere) so sales sees context.
  - **Deferred loading** — the external widget script is fetched on browser idle or first interaction, so it does not block initial render.
  - Reads `PUBLIC_INTERCOM_APP_ID`; renders nothing when unset (mirrors the affiliate-tracker guard), so the build is safe before the value is set.
- **`src/pages/privacy-policy.mdx`** / **`src/pages/cookie-policy.mdx`** — disclose Intercom as a processor and as a cookie-setting live-chat provider; dates bumped; corrected a pre-existing false reference to a "Cookie Consent Manager" that does not exist.
- **`.claude/rules/withotto-app-intercom.md`** (new) + a note in **`withotto-app-conventions.md`** — how the integration works plus the recommended Intercom dashboard checklist for the sales setup (sales greeting, qualification/routing by the `product` attribute, brand appearance, office hours).

## Required to go live

Set **`PUBLIC_INTERCOM_APP_ID`** (the workspace id) in Netlify's build environment variables. The widget renders nothing until it is set.

## Verification

- `pnpm build` ✓ · `pnpm format:check` ✓ · no new type errors introduced.
- `/code-review` (xhigh) — 0 findings.
- E2E (local dev server, browser): widget injects on both `.astro` and `.mdx` pages, loads deferred (after idle/interaction, not render-blocking), and `product` resolves correctly per page. Live launcher confirmed manually with the real workspace id.

## Notes

- No npm dependency added — the Messenger is a JS snippet.
- No Identity Verification secret is needed (anonymous visitors only).
- The Codex adversarial review could not run during verification (account usage limit); the Claude `/code-review` pass ran in full.
